### PR TITLE
small fix for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Include the JS source:
     <!-- Syntax highlighting Modes -->
     
     <!-- javascript -->
-    <script src="../mode/javascript/javascript.js"></script>
+    <script src="../extensions/codemirror/mode/javascript/javascript.js"></script>
 
     <!-- html mode (note html mode requires xml, css and javascript) -->
     <script src="../extensions/codemirror/mode/xml/xml.js"></script>


### PR DESCRIPTION
The included readme is very helpful for linking codemirror into an existing deck, however the script tag to include the javascript mode is incorrect.  Thought this fix might help people like me who tend to blindly copy example code :)

Thanks for creating this great extension.
