### PR TITLE
fixes slides that does not scale correctly with codemirror elements

### DIFF
--- a/deck.codemirror.js
+++ b/deck.codemirror.js
@@ -222,26 +222,11 @@
   };
 
   $d.bind('deck.init', function() {
-    
-    // codemirrorify current and next slide, since we're in the beginning.
-    codemirrorify($.deck('getSlide', 0));
-    codemirrorify($.deck('getSlide', 1));
-  });
-
-  $d.bind('deck.change', function(event, from, to) {
-    var $slides    = $[deck]('getSlides');
-    // codemirrorify previous slide
-    if (to > 0) {
-      codemirrorify($.deck('getSlide', to - 1));
-    } 
-    
-    // codemirrorify current slide
-    codemirrorify($.deck('getSlide', to));
-
-    // codemirrorify next slide
-    if (to+1 < $slides.length) {
-      codemirrorify($.deck('getSlide', to + 1));
-    }
+    //codemirrorify all the decks so that scale is correctly computed
+    var slides = $[deck]('getSlides');
+    $(slides).each(function(i){
+        codemirrorify($.deck('getSlide', i));
+    });
   });
 })(jQuery, 'deck', this);
 


### PR DESCRIPTION
Whenever there are slides that needs to be scaled and has codemirror elements, they are not scaled correctly because the innerHeight of the element cannot be computed correctly since codemirror changes it.

This pull request makes it calculate the codemirror elements for all elements in the deck on initialization, not only the current and next slide. 

In terms of performance: I have tested this on my 10inch macbook air with a large deck (50slides and lots and lots of code) and there are no noticeable difference. It would be extremely surprising if there were any perf issues with this, and I think it is better to have correctly rendered slides than a bit of a lag on initialization of the code deck. 
